### PR TITLE
Fix require faraday in middleware

### DIFF
--- a/app/middlewares/translation_engine/connection_exception_middleware.rb
+++ b/app/middlewares/translation_engine/connection_exception_middleware.rb
@@ -1,3 +1,5 @@
+require 'faraday'
+
 class TranslationEngine::ConnectionExceptionMiddleware < Faraday::Middleware
   def call(env)
     begin


### PR DESCRIPTION
Fix error -> 
/app/vendor/bundle/ruby/2.2.0/bundler/gems/translation-engine-51f4838b1bc1/app/middlewares/translation_engine/connection_exception_middleware.rb:1:in `<top (required)>': uninitialized constant Faraday (NameError)
