### PR TITLE
Safe body access, fixes NoMethodError

### DIFF
--- a/app/models/translation_engine/backend.rb
+++ b/app/models/translation_engine/backend.rb
@@ -33,7 +33,7 @@ class TranslationEngine::Backend < I18n::Backend::Simple
   end
 
   def download_master
-    if (yml_data = connection.get_translations.body)
+    if (yml_data = connection.get_translations.try(:body))
       Rails.logger.info { 'Updating from translation server - master' }
       YAML.load(yml_data).each do |locale, translations|
         store_translations locale, translations
@@ -42,7 +42,7 @@ class TranslationEngine::Backend < I18n::Backend::Simple
   end
 
   def download_release
-    if (yml_data = connection.get_release(release).body)
+    if (yml_data = connection.get_release(release).try(:body))
       Rails.logger.info { "Updating from translation server - #{release}" }
       YAML.load(yml_data).each do |locale, translations|
         store_translations locale, translations

--- a/app/models/translation_engine/downloader.rb
+++ b/app/models/translation_engine/downloader.rb
@@ -26,7 +26,7 @@ class TranslationEngine::Downloader
   def store_release(release)
     locale = release.split('_')[0...-1].join('_')
     filename = releases_dir.join("#{locale.downcase}.yml")
-    if (yml_data = connection.get_release(release).body)
+    if (yml_data = connection.get_release(release).try(:body))
       Rails.logger.info { "Storing release #{release} to #{filename}" }
       write(filename, yml_data)
     end
@@ -55,7 +55,7 @@ class TranslationEngine::Downloader
   def receive_translations
     return if self.class.etag?(connection.get_translations_head[:etag])
 
-    connection.get_translations.body
+    connection.get_translations.try(:body)
   end
 
   def releases_dir


### PR DESCRIPTION
Fixes `undefined method 'body' for {}:Hash`, caused by timeouts (connection failures).